### PR TITLE
Adding optima to tabular benchmarks (LCBench)

### DIFF
--- a/src/mfpbench/lcbench_tabular/benchmark.py
+++ b/src/mfpbench/lcbench_tabular/benchmark.py
@@ -293,7 +293,7 @@ class LCBenchTabularBenchmark(TabularBenchmark):
         )
 
         # for tabular benchmarks, the `global` optima can be retrieved
-        table = _get_optima(table)
+        optimal_metrics = _get_optima(table)
 
         super().__init__(
             table=table,  # type: ignore
@@ -307,10 +307,11 @@ class LCBenchTabularBenchmark(TabularBenchmark):
             seed=seed,
             prior=prior,
             perturb_prior=perturb_prior,
+            optimal_metrics=optimal_metrics
         )
 
 
-def _get_optima(table: pd.DataFrame) -> pd.DataFrame:
+def _get_optima(table: pd.DataFrame) -> dict:
     metrics = [
         ("val_accuracy", max),
         ("val_cross_entropy", min),
@@ -319,7 +320,8 @@ def _get_optima(table: pd.DataFrame) -> pd.DataFrame:
         ("test_cross_entropy", min),
         ("test_balanced_accuracy", max)
     ]
-    for i, (metric_name, metric_order) in enumerate(metrics):
-        new_col = f"optima-{metric_name}"
-        table.loc[:, new_col] = metric_order(table.loc[:, metric_name])
-    return table
+    optimal_metrics = {
+        metric_name: metric_order(table.loc[:, metric_name])
+        for i, (metric_name, metric_order) in enumerate(metrics)
+    }
+    return optimal_metrics

--- a/src/mfpbench/tabular.py
+++ b/src/mfpbench/tabular.py
@@ -64,6 +64,7 @@ class TabularBenchmark(Benchmark[CTabular, R, F]):
         seed: int | None = None,
         prior: str | Path | CTabular | Mapping[str, Any] | None = None,
         perturb_prior: float | None = None,
+        optimal_metrics: dict | None = None
     ):
         """Initialize the benchmark.
 
@@ -189,6 +190,7 @@ class TabularBenchmark(Benchmark[CTabular, R, F]):
         self.config_keys = sorted(config_keys)
         self.result_keys = sorted(result_keys)
         self.fidelity_range = (start, end, step)  # type: ignore
+        self.optimal_metrics = optimal_metrics
 
         super().__init__(
             name=name,


### PR DESCRIPTION
For tabular benchmarks, this is a *must-have* option.

Can also be added as a property to the Result object.

Currently, I want to access this as a benchmark property ideally and not have to query for this. Hence, adding it for each row.

Happy to discuss the best way to retrieve it.

This option can be kept general and continuous benchmarks can have this as `None`. Also could be used as a proxy check to test if a benchmark is tabular or surrogate.