### PR TITLE
Add test metric for LCBenchTabular

### DIFF
--- a/src/mfpbench/benchmark.py
+++ b/src/mfpbench/benchmark.py
@@ -102,6 +102,9 @@ class Benchmark(Generic[C, R, F], ABC):
         """
         if value_metric is None:
             value_metric = result_type.default_value_metric
+            value_metric_test = result_type.default_value_metric_test
+        else:
+            value_metric_test = result_type.get_test_for_val_metric(value_metric)
 
         if cost_metric is None:
             cost_metric = result_type.default_cost_metric
@@ -110,6 +113,7 @@ class Benchmark(Generic[C, R, F], ABC):
         self.seed = seed
         self.space = space
         self.value_metric = value_metric
+        self.value_metric_test = value_metric_test
         self.cost_metric = cost_metric
         self.fidelity_range: tuple[F, F, F] = fidelity_range
         self.fidelity_name = fidelity_name
@@ -282,6 +286,7 @@ class Benchmark(Generic[C, R, F], ABC):
             __config = {k: __config.get(v, v) for k, v in _reverse_renames.items()}
 
         value_metric = value_metric if value_metric is not None else self.value_metric
+        value_metric_test = value_metric_test if value_metric is not None else self.value_metric_test
         cost_metric = cost_metric if cost_metric is not None else self.cost_metric
 
         return self.Result.from_dict(
@@ -289,6 +294,7 @@ class Benchmark(Generic[C, R, F], ABC):
             fidelity=at,
             result=self._objective_function(__config, at=at),
             value_metric=str(value_metric),
+            value_metric_test=value_metric_test,
             cost_metric=str(cost_metric),
             renames=self._result_renames,
         )
@@ -329,6 +335,7 @@ class Benchmark(Generic[C, R, F], ABC):
             _reverse_renames = {v: k for k, v in self._config_renames.items()}
             __config = {k: __config.get(v, v) for k, v in _reverse_renames.items()}
 
+        value_metric_test = value_metric_test if value_metric is not None else self.value_metric_test
         value_metric = value_metric if value_metric is not None else self.value_metric
         cost_metric = cost_metric if cost_metric is not None else self.cost_metric
 
@@ -338,6 +345,7 @@ class Benchmark(Generic[C, R, F], ABC):
                 fidelity=fidelity,
                 result=result,
                 value_metric=str(value_metric),
+                value_metric_test=value_metric_test,
                 cost_metric=str(cost_metric),
                 renames=self._result_renames,
             )

--- a/src/mfpbench/benchmark.py
+++ b/src/mfpbench/benchmark.py
@@ -73,6 +73,7 @@ class Benchmark(Generic[C, R, F], ABC):
         prior: str | Path | C | Mapping[str, Any] | None = None,
         perturb_prior: float | None = None,
         value_metric: str | None = None,
+        value_metric_test: str | None = None,
         cost_metric: str | None = None,
     ):
         """Initialize the benchmark.
@@ -102,9 +103,8 @@ class Benchmark(Generic[C, R, F], ABC):
         """
         if value_metric is None:
             value_metric = result_type.default_value_metric
+        if value_metric_test is None:
             value_metric_test = result_type.default_value_metric_test
-        else:
-            value_metric_test = result_type.get_test_for_val_metric(value_metric)
 
         if cost_metric is None:
             cost_metric = result_type.default_cost_metric
@@ -254,6 +254,7 @@ class Benchmark(Generic[C, R, F], ABC):
         *,
         at: F | None = None,
         value_metric: str | None = None,
+        value_metric_test: str | None = None,
         cost_metric: str | None = None,
     ) -> R:
         """Submit a query and get a result.
@@ -286,7 +287,7 @@ class Benchmark(Generic[C, R, F], ABC):
             __config = {k: __config.get(v, v) for k, v in _reverse_renames.items()}
 
         value_metric = value_metric if value_metric is not None else self.value_metric
-        value_metric_test = value_metric_test if value_metric is not None else self.value_metric_test
+        value_metric_test = value_metric_test if value_metric_test is not None else self.value_metric_test
         cost_metric = cost_metric if cost_metric is not None else self.cost_metric
 
         return self.Result.from_dict(
@@ -307,6 +308,7 @@ class Benchmark(Generic[C, R, F], ABC):
         to: F | None = None,
         step: F | None = None,
         value_metric: str | None = None,
+        value_metric_test: str | None = None,
         cost_metric: str | None = None,
     ) -> list[R]:
         """Get the full trajectory of a configuration.
@@ -335,8 +337,8 @@ class Benchmark(Generic[C, R, F], ABC):
             _reverse_renames = {v: k for k, v in self._config_renames.items()}
             __config = {k: __config.get(v, v) for k, v in _reverse_renames.items()}
 
-        value_metric_test = value_metric_test if value_metric is not None else self.value_metric_test
         value_metric = value_metric if value_metric is not None else self.value_metric
+        value_metric_test = value_metric_test if value_metric_test is not None else self.value_metric_test
         cost_metric = cost_metric if cost_metric is not None else self.cost_metric
 
         return [

--- a/src/mfpbench/lcbench_tabular/benchmark.py
+++ b/src/mfpbench/lcbench_tabular/benchmark.py
@@ -151,14 +151,6 @@ class LCBenchTabularResult(Result[LCBenchTabularConfig, int]):
     default_value_metric_test: ClassVar[str] = "test_balanced_accuracy"
     default_cost_metric: ClassVar[str] = "time"
 
-    def get_test_for_val_metric(val: str) -> str:
-        dict_map = {
-            "val_accuracy": "test_accuracy",
-            "val_balanced_accuracy": "test_balanced_accuracy",
-            "val_cross_entropy": "test_cross_entropy"
-        }
-        return dict_map[val]
-
     time: Metric.Value
     val_accuracy: Metric.Value
     test_accuracy: Metric.Value
@@ -223,6 +215,7 @@ class LCBenchTabularBenchmark(TabularBenchmark):
         prior: str | Path | LCBenchTabularConfig | Mapping[str, Any] | None = None,
         perturb_prior: float | None = None,
         value_metric: str | None = None,
+        value_metric_test: str | None = None,
         cost_metric: str | None = None,
     ) -> None:
         """Initialize the benchmark.
@@ -291,6 +284,7 @@ class LCBenchTabularBenchmark(TabularBenchmark):
             result_type=LCBenchTabularResult,
             config_type=LCBenchTabularConfig,
             value_metric=value_metric,
+            value_metric_test=value_metric_test,
             cost_metric=cost_metric,
             space=space,
             seed=seed,

--- a/src/mfpbench/lcbench_tabular/benchmark.py
+++ b/src/mfpbench/lcbench_tabular/benchmark.py
@@ -148,7 +148,16 @@ class LCBenchTabularResult(Result[LCBenchTabularConfig, int]):
         "time": Metric(minimize=True, bounds=(0, np.inf)),
     }
     default_value_metric: ClassVar[str] = "val_balanced_accuracy"
+    default_value_metric_test: ClassVar[str] = "test_balanced_accuracy"
     default_cost_metric: ClassVar[str] = "time"
+
+    def get_test_for_val_metric(val: str) -> str:
+        dict_map = {
+            "val_accuracy": "test_accuracy",
+            "val_balanced_accuracy": "test_balanced_accuracy",
+            "val_cross_entropy": "test_cross_entropy"
+        }
+        return dict_map[val]
 
     time: Metric.Value
     val_accuracy: Metric.Value

--- a/src/mfpbench/result.py
+++ b/src/mfpbench/result.py
@@ -118,6 +118,12 @@ class Result(ABC, Generic[C, F]):
         return self[self.value_metric].score
 
     @property
+    def val_score(self) -> float:
+        """The score of interest."""
+        # to maintain backward compatibility
+        return self.score
+
+    @property
     def test_score(self) -> float:
         """The score of interest."""
         return self[self.value_metric_test].score

--- a/src/mfpbench/result.py
+++ b/src/mfpbench/result.py
@@ -27,6 +27,9 @@ class Result(ABC, Generic[C, F]):
     default_value_metric: ClassVar[str]
     """The default metric to use for this result."""
 
+    default_value_metric_test: ClassVar[str]
+    """The default test metric to use for this result."""
+
     default_cost_metric: ClassVar[str]
     """The default cost to use for this result."""
 
@@ -37,6 +40,9 @@ class Result(ABC, Generic[C, F]):
     """The config used to generate this result."""
 
     value_metric: str
+    """The metric to use for this result."""
+
+    value_metric_test: str
     """The metric to use for this result."""
 
     cost_metric: str
@@ -50,6 +56,7 @@ class Result(ABC, Generic[C, F]):
         result: Mapping[str, float],
         *,
         value_metric: str | None = None,
+        value_metric_test: str | None = None,
         cost_metric: str | None = None,
         renames: Mapping[str, str] | None = None,
     ) -> Self:
@@ -64,8 +71,11 @@ class Result(ABC, Generic[C, F]):
         }
         if renames is not None:
             values = {renames.get(k, k): v for k, v in values.items()}
+        
         if value_metric is None:
             value_metric = cls.default_value_metric
+            value_metric_test = cls.default_value_metric_test
+        
         if cost_metric is None:
             cost_metric = cls.default_cost_metric
 
@@ -73,6 +83,7 @@ class Result(ABC, Generic[C, F]):
             config=config,
             fidelity=fidelity,
             value_metric=value_metric,
+            value_metric_test=value_metric_test,
             cost_metric=cost_metric,
             **values,  # type: ignore
         )
@@ -97,9 +108,19 @@ class Result(ABC, Generic[C, F]):
         return self[self.value_metric].error
 
     @property
+    def test_error(self) -> float:
+        """The error of interest."""
+        return self[self.value_metric_test].error
+
+    @property
     def score(self) -> float:
         """The score of interest."""
         return self[self.value_metric].score
+
+    @property
+    def test_score(self) -> float:
+        """The score of interest."""
+        return self[self.value_metric_test].score
 
     @property
     def values(self) -> dict[str, Any]:

--- a/src/mfpbench/tabular.py
+++ b/src/mfpbench/tabular.py
@@ -38,6 +38,7 @@ class TabularBenchmark(Benchmark[CTabular, R, F]):
         result_type: type[R],
         config_type: type[CTabular],
         value_metric: str | None = None,
+        value_metric_test: str | None = None,
         cost_metric: str | None = None,
         space: ConfigurationSpace | None = None,
         seed: int | None = None,
@@ -171,6 +172,7 @@ class TabularBenchmark(Benchmark[CTabular, R, F]):
             prior=prior,
             perturb_prior=perturb_prior,
             value_metric=value_metric,
+            value_metric_test=value_metric_test,
             cost_metric=cost_metric,
         )
 
@@ -196,6 +198,7 @@ class TabularBenchmark(Benchmark[CTabular, R, F]):
         *,
         at: F | None = None,
         value_metric: str | None = None,
+        value_metric_test: str | None = None,
         cost_metric: str | None = None,
     ) -> R:
         """Submit a query and get a result.
@@ -241,6 +244,7 @@ class TabularBenchmark(Benchmark[CTabular, R, F]):
             __config = {k: __config.get(v, v) for k, v in _reverse_renames.items()}
 
         value_metric = value_metric if value_metric is not None else self.value_metric
+        value_metric_test = value_metric_test if value_metric_test is not None else self.value_metric_test
         cost_metric = cost_metric if cost_metric is not None else self.cost_metric
 
         return self.Result.from_dict(
@@ -248,6 +252,7 @@ class TabularBenchmark(Benchmark[CTabular, R, F]):
             fidelity=at,
             result=self._objective_function(__config, at=at),
             value_metric=str(value_metric),
+            value_metric_test=value_metric_test,
             cost_metric=str(cost_metric),
             renames=self._result_renames,
         )
@@ -261,6 +266,7 @@ class TabularBenchmark(Benchmark[CTabular, R, F]):
         to: F | None = None,
         step: F | None = None,
         value_metric: str | None = None,
+        value_metric_test: str | None = None,
         cost_metric: str | None = None,
     ) -> list[R]:
         """Submit a query and get a result.
@@ -309,6 +315,7 @@ class TabularBenchmark(Benchmark[CTabular, R, F]):
             __config = {k: __config.get(v, v) for k, v in _reverse_renames.items()}
 
         value_metric = value_metric if value_metric is not None else self.value_metric
+        value_metric_test = value_metric_test if value_metric_test is not None else self.value_metric_test
         cost_metric = cost_metric if cost_metric is not None else self.cost_metric
 
         return [
@@ -317,6 +324,7 @@ class TabularBenchmark(Benchmark[CTabular, R, F]):
                 fidelity=fidelity,
                 result=result,
                 value_metric=str(value_metric),
+                value_metric_test=value_metric_test,
                 cost_metric=str(cost_metric),
                 renames=self._result_renames,
             )


### PR DESCRIPTION
Since we want to optimize for validation but perhaps plot test.

Also, passing the benchmark specific key for the corresponding test metric in query/trajectory is not convenient.

With the design of this PR, each instance of the benchmark will have a primary validation-test-key that will determine the calls to `.error` or `.score` and correspondingly `test_error` and `test_score`.