### PR TITLE
Update pyproject.toml for configspace version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ name = "mf-prior-bench"
 dependencies = [
   "pyyaml",
   "numpy",
-  "configspace<=0.7",
+  "configspace<=0.7.1",
   "pandas",
   "more_itertools",
   "pyarrow"


### PR DESCRIPTION
Installing `confispace==0.7.1` crashes when trying to use YAHPO so ideally the version of this is conditional on the benchmark required.

This is likely a temporary fix for environments to work with other packages having a "^0.7" in its dependency list.